### PR TITLE
feat: API Registrasi User

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,11 +6,13 @@
       "name": "vibe-coding",
       "dependencies": {
         "@elysiajs/swagger": "^1.3.1",
+        "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
         "mysql2": "^3.20.0",
       },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/bun": "latest",
         "drizzle-kit": "^0.31.10",
       },
@@ -94,6 +96,8 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
@@ -101,6 +105,8 @@
     "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:studio": "bunx drizzle-kit studio"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "latest",
     "drizzle-kit": "^0.31.10"
   },
@@ -18,6 +19,7 @@
   },
   "dependencies": {
     "@elysiajs/swagger": "^1.3.1",
+    "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
     "mysql2": "^3.20.0"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,5 +4,6 @@ export const users = mysqlTable("users", {
   id: int("id").primaryKey().autoincrement(),
   name: varchar("name", { length: 255 }).notNull(),
   email: varchar("email", { length: 255 }).notNull().unique(),
+  password: varchar("password", { length: 255 }).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Elysia } from "elysia";
 import { swagger } from "@elysiajs/swagger";
-import { userRoutes } from "./routes";
+import { userRoutes } from "./routes/user-routes";
 
 const app = new Elysia()
   .use(

--- a/src/routes/user-routes.ts
+++ b/src/routes/user-routes.ts
@@ -1,0 +1,38 @@
+import { Elysia, t } from "elysia";
+import { registerUser } from "../services/user-service";
+
+export const userRoutes = new Elysia({ prefix: "/api/users" }).post(
+  "/",
+  async ({ body, set }) => {
+    try {
+      const user = await registerUser(body.name, body.email, body.password);
+
+      set.status = 201;
+      return {
+        message: "OK",
+        data: user,
+      };
+    } catch (error) {
+      if (error instanceof Error && error.message === "User already exists") {
+        set.status = 400;
+        return {
+          message: "User already exists",
+          error: "Bad Request",
+        };
+      }
+
+      set.status = 500;
+      return {
+        message: "Internal server error",
+        error: "Internal Server Error",
+      };
+    }
+  },
+  {
+    body: t.Object({
+      name: t.String(),
+      email: t.String(),
+      password: t.String(),
+    }),
+  }
+);

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,0 +1,43 @@
+import { eq } from "drizzle-orm";
+import bcrypt from "bcryptjs";
+import { db } from "../db";
+import { users } from "../db/schema";
+
+export async function registerUser(
+  name: string,
+  email: string,
+  password: string
+) {
+  // Cek apakah email sudah terdaftar
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, email));
+
+  if (existing.length > 0) {
+    throw new Error("User already exists");
+  }
+
+  // Hash password dengan bcrypt
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  // Insert user baru
+  const result = await db.insert(users).values({
+    name,
+    email,
+    password: hashedPassword,
+  });
+
+  // Ambil user yang baru dibuat (tanpa password)
+  const newUser = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      createdAt: users.createdAt,
+    })
+    .from(users)
+    .where(eq(users.id, Number(result[0].insertId)));
+
+  return newUser[0];
+}


### PR DESCRIPTION
## Summary

Implementasi fitur registrasi user baru dengan endpoint `POST /api/users`.

## Changes

- Tambah field `password` (varchar 255, bcrypt hash) ke tabel `users`
- Buat `src/services/user-service.ts` — logic registrasi (cek duplikat email, hash password, insert DB)
- Buat `src/routes/user-routes.ts` — endpoint `POST /api/users` dengan validasi request
- Update `src/index.ts` — ganti import ke route baru
- Tambah dependency `bcryptjs`

## Testing

| Test | Result |
|------|--------|
| Registrasi user baru | ✅ 201 Created |
| Duplikat email | ✅ 400 Bad Request |
| Password tidak di-return | ✅ Verified |

Closes #4