### PR TITLE
feat: API Logout User

### DIFF
--- a/src/routes/user-routes.ts
+++ b/src/routes/user-routes.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from "elysia";
-import { registerUser, loginUser, getCurrentUser } from "../services/user-service";
+import { registerUser, loginUser, getCurrentUser, logoutUser } from "../services/user-service";
 
 export const userRoutes = new Elysia({ prefix: "/api/users" })
   .post(
@@ -88,6 +88,43 @@ export const userRoutes = new Elysia({ prefix: "/api/users" })
 
         return {
           data: user,
+        };
+      } catch (error) {
+        if (error instanceof Error && error.message === "Unauthorized") {
+          set.status = 401;
+          return {
+            message: "Unauthorized",
+            error: "Bad Request",
+          };
+        }
+
+        set.status = 500;
+        return {
+          message: "Internal server error",
+          error: "Internal Server Error",
+        };
+      }
+    }
+  )
+  .delete(
+    "/logout",
+    async ({ headers, set }) => {
+      try {
+        const authorization = headers["authorization"];
+
+        if (!authorization || !authorization.startsWith("Bearer ")) {
+          set.status = 401;
+          return {
+            message: "Unauthorized",
+            error: "Bad Request",
+          };
+        }
+
+        const token = authorization.replace("Bearer ", "");
+        await logoutUser(token);
+
+        return {
+          data: "OK",
         };
       } catch (error) {
         if (error instanceof Error && error.message === "Unauthorized") {

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -104,3 +104,20 @@ export async function getCurrentUser(token: string) {
 
   return user[0]!;
 }
+
+export async function logoutUser(token: string) {
+  // Cari session berdasarkan token
+  const session = await db
+    .select()
+    .from(sessions)
+    .where(eq(sessions.token, token));
+
+  if (session.length === 0) {
+    throw new Error("Unauthorized");
+  }
+
+  // Hapus session dari database
+  await db.delete(sessions).where(eq(sessions.token, token));
+
+  return "OK";
+}


### PR DESCRIPTION
## Summary

Implementasi endpoint logout user yang menghapus session token dari database.

## Changes

- Tambah fungsi `logoutUser` di `src/services/user-service.ts` (cari session by token, hapus dari DB)
- Tambah route `DELETE /api/users/logout` di `src/routes/user-routes.ts` dengan Bearer token auth

## Testing

| Test | Result |
|------|--------|
| Logout berhasil | ✅ 200 — `{data: OK}` |
| Token tidak valid setelah logout (get current user) | ✅ 401 — Unauthorized |
| Tanpa header Authorization | ✅ 401 — Unauthorized |
| Token tidak valid | ✅ 401 — Unauthorized |

Closes #10